### PR TITLE
Release v1 0.2

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,35 +1,35 @@
 name: Release
-
 on:
-  push:
-    branches:
-      - main
-
+  # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
 jobs:
   release:
-    name: Publish Release
+    name: Release
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [20.x]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v2
         with:
           fetch-depth: 0
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v3
+      - name: Automatic GitHub Release
+        uses: justincy/github-action-npm-release@2.0.1
+        id: release
+      - uses: actions/setup-node@v1
+        if: steps.release.outputs.released == 'true'
         with:
-          node-version: 20
-          registry-url: "https://registry.npmjs.org"
-
-      - name: Install dependencies
-        run: npm install
-
-      - name: Build the package
-        run: npm run build
-
-      - name: Publish to npm
-        run: npm publish --access public
+          registry-url: "https://npm.pkg.github.com"
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Publish
+        if: steps.release.outputs.released == 'true'
+        run: |
+          npm install
+          npm publish
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,35 +1,35 @@
 name: Release
+
 on:
-  # Allows you to run this workflow manually from the Actions tab
+  push:
+    tags:
+      - "v*.*.*"
+
   workflow_dispatch:
 
 jobs:
   release:
-    name: Release
+    name: Publish Release
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version: [16.x, 18.x, 20.x]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: Automatic GitHub Release
-        uses: justincy/github-action-npm-release@2.0.1
-        id: release
-      - uses: actions/setup-node@v1
-        if: steps.release.outputs.released == 'true'
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
         with:
-          registry-url: "https://npm.pkg.github.com"
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v2
-        with:
-          node-version: ${{ matrix.node-version }}
-      - name: Publish
-        if: steps.release.outputs.released == 'true'
-        run: |
-          npm install
-          npm publish
+          node-version: 20
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Build the package
+        run: npm run build
+
+      - name: Publish to npm
+        run: npm publish --access public
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,8 +2,8 @@ name: Release
 
 on:
   push:
-    tags:
-      - "v*.*.*"
+    branches:
+      - main
 
   workflow_dispatch:
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bsolus/kuantokusta-seller-api-node-sdk",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "A Node.js SDK for interacting with the KuantoKusta Seller API, providing seamless integration for sellers.",
   "main": "./index.ts",
   "types": "./index.d.ts",
@@ -31,12 +31,19 @@
     "url": "https://github.com/bsolus/kuantokusta-seller-api-node-sdk/issues"
   },
   "homepage": "https://github.com/bsolus/kuantokusta-seller-api-node-sdk#readme",
+  "scripts": {
+    "build": "tsc",
+    "lint": "eslint .",
+    "test": "jest",
+    "prepare": "npm run build",
+    "prepublishOnly": "npm test && npm run lint"
+  },
   "dependencies": {
     "api": "^6.1.2",
     "json-schema-to-ts": "^2.12.0",
     "oas": "^20.10.3"
   },
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com"
+    "access": "public"
   }
 }


### PR DESCRIPTION
This pull request modifies the GitHub Actions workflow for publishing releases. The most important changes include enabling manual workflow dispatch, updating the Node.js setup, and changing the publish process.

Changes to workflow dispatch:

* [`.github/workflows/publish.yml`](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7L2-R35): Enabled manual workflow dispatch by adding `workflow_dispatch` to the `on` section.

Updates to Node.js setup:

* [`.github/workflows/publish.yml`](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7L2-R35): Updated the Node.js setup to use a matrix strategy with Node.js version 20.x, and changed the `actions/setup-node` version to v2.

Changes to the publish process:

* [`.github/workflows/publish.yml`](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7L2-R35): Replaced the manual steps for installing dependencies, building the package, and publishing to npm with a single step that runs these commands if the release is successful.
* [`.github/workflows/publish.yml`](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7L2-R35): Changed the `NODE_AUTH_TOKEN` to use `secrets.GITHUB_TOKEN` instead of `secrets.NPM_TOKEN`.